### PR TITLE
Set proxy_intercept_errors off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#15] Set `proxy_intercept_errors off;` so that dogus like bluespice work properly.
+- Update ingress-nginx to 1.5.1
 
 ## [v1.3.0-3] - 2023-02-06
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/ingress-nginx/controller:v1.3.0
+FROM k8s.gcr.io/ingress-nginx/controller:v1.5.1
 
 LABEL maintainer="hello@cloudogu.com" \
       NAME="k8s-testing/nginx-ingress" \

--- a/k8s/nginx-ingress.yaml
+++ b/k8s/nginx-ingress.yaml
@@ -109,6 +109,13 @@ rules:
       - get
       - create
       - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/resources/etc/nginx/ces-config/errors.conf
+++ b/resources/etc/nginx/ces-config/errors.conf
@@ -1,4 +1,6 @@
-proxy_intercept_errors on;
+# proxy_intercept_errors on leads to wrong doing dogus because e.g. bluespice return 404 on the CreateNewPage Response.
+# Turn this on if dogus can bring their own exception for specific paths.
+proxy_intercept_errors off;
 
 # define custom error pages
 error_page 404 /errors/404.html;


### PR DESCRIPTION
Dogus like confluence and bluespice return errors with responses to create new pages. The nginx intercept those error and shows custom error pages instead of a html to create a new doc page. We have to turn this option off until dogus can bring their own execption for this.

Resolves #15 