### PR TITLE
[#45] Enable Snippet annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#45] Adjust configuration for snippet annotations to enable redirection of alternative fqdns.
 
 ## [v1.12.1-2] - 2025-04-23
 ### Changed

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -5,6 +5,7 @@ Im Folgenden finden Sie die Release Notes für das nginx-ingress Dogu.
 Technische Details zu einem Release finden Sie im zugehörigen Changelog.
 
 ## [Unreleased]
+* Anpassung der Konfiguration um Umleitung zu alternativen FQDNs zu ermöglichen.
 
 ## [v1.12.1-2] - 2025-04-23
 * Die Verwendung von Speicher und CPU wurden für die Kubernetes-Multinode-Umgebung optimiert.

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -5,6 +5,7 @@ Below you will find the release notes for the nginx-ingress Dogu.
 Technical details on a release can be found in the corresponding Changelog.
 
 ## [Unreleased]
+* Adjusting the configuration to enable redirection to alternative FQDNs.
 
 ## [v1.12.1-2] - 2025-04-23
 * Usage of memory and CPU was optimized for the Kubernetes Mutlinode environment.

--- a/k8s/nginx-ingress.yaml
+++ b/k8s/nginx-ingress.yaml
@@ -184,7 +184,8 @@ metadata:
 # see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
 apiVersion: v1
 data:
-  allow-snippet-annotations: "false"
+  allow-snippet-annotations: "true"
+  annotations-risk-level: "Critical"
   proxy-set-headers: "{{ .Namespace }}/nginx-ingress-custom-headers"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Resolve #45 

Snippet annotations are needed to use redirect of the k8s-service-discovery as the annotation: `nginx.ingress.kubernetes.io/permanent-redirect` only works for plain hostnames. If the want to preserve the request path the annotation `nginx.ingress.kubernetes.io/server-snippet` needs to be used. The server-snippet annotation needs annotations-risk-level config to be set to `Critical`.